### PR TITLE
Updated to project version 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <outputFile>C:\Users\mecha\Desktop\Dev\Minecraft Server\plugins\ShowDamage-1.0.jar</outputFile>
+
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ru.xw1w1.showdamage</groupId>
     <artifactId>ShowDamage</artifactId>
-    <version>1.1.1</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>ShowDamage</name>
@@ -39,6 +39,7 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <outputFile>C:\Users\mecha\Desktop\Dev\Minecraft Server\plugins\ShowDamage-1.0.jar</outputFile>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/ru/xw1w1/showdamage/Main.java
+++ b/src/main/java/ru/xw1w1/showdamage/Main.java
@@ -1,14 +1,21 @@
 package ru.xw1w1.showdamage;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import ru.xw1w1.showdamage.listeners.EntityDamageListener;
+import ru.xw1w1.showdamage.utils.DamageData;
+
 import java.io.File;
+import java.util.*;
 
 public final class Main extends JavaPlugin {
+
+    private final static Map<Location, DamageData> locationDamageEntityMap = new LinkedHashMap<>();  // This is really difficult to name, it keys Chunks to Entity UUID
+
     @Override
     public void onEnable() {
         getServer().getPluginManager().registerEvents(new EntityDamageListener(), this);
@@ -34,4 +41,35 @@ public final class Main extends JavaPlugin {
         }
         return YamlConfiguration.loadConfiguration(configFile);
     }
+    public static class MultiDamageSystem {
+        public static void appendToData(Location key) {
+            locationDamageEntityMap.get(key).append();
+        }
+        public static void putDataInMap(Location key, DamageData data) {
+            locationDamageEntityMap.put(key, data);
+        }
+        public static void reduceSizeInData(Location key) {
+            locationDamageEntityMap.get(key).reduce();
+        }
+        public static int getSize(Location key) {
+            return locationDamageEntityMap.get(key).size();
+        }
+        public static Set<Location> keySet(){
+            return locationDamageEntityMap.keySet();
+        }
+        public static void deleteEntry(Location key) {
+            locationDamageEntityMap.remove(key);
+        }
+        public static int getCount(Location key) {
+            return locationDamageEntityMap.get(key).count();
+        }
+        public static String getDamageDealt(Location key) {
+            return locationDamageEntityMap.get(key).getDamageDealt();
+        }
+        public static boolean isDamagedBySword(Location key) {
+            return locationDamageEntityMap.get(key).isDamagedBySword();
+        }
+    }
+
+
 }

--- a/src/main/java/ru/xw1w1/showdamage/listeners/EntityDamageListener.java
+++ b/src/main/java/ru/xw1w1/showdamage/listeners/EntityDamageListener.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.AbstractArrow;
+import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -12,26 +13,40 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.jetbrains.annotations.NotNull;
 import ru.xw1w1.showdamage.Main;
+import ru.xw1w1.showdamage.utils.DamageData;
 import ru.xw1w1.showdamage.utils.ShowDamage;
-import ru.xw1w1.showdamage.utils.TextUtils;
+import static ru.xw1w1.showdamage.utils.TextUtils.*;
 
 import java.text.DecimalFormat;
+import java.util.Iterator;
 
-public class EntityDamageListener extends TextUtils implements Listener {
+
+
+public class EntityDamageListener implements Listener {
+
+    private enum MultiDamageEndResult {
+        EXPLOSION_DONE,
+        SINGLE_ENTITY_ATTACK_DONE,
+        SWEEP_ENTITY_ATTACK_DONE,
+        NOT_DONE,
+
+    }
     @EventHandler
     private void onEntityDamage(EntityDamageByEntityEvent event) {
         @NotNull final FileConfiguration config = Main.getInstance().getConfiguration();
 
-        if (config.getBoolean("messages.damage-visible")) {
-            @NotNull final DecimalFormat df = new DecimalFormat("0.00");
-            @NotNull final String damage = df.format(event.getDamage());
-            @NotNull final Location location = event.getEntity().getLocation();
-            @NotNull final Location spawnLocation = new Location(location.getWorld(), location.getX(), location.getY() + (event.getEntity().getBoundingBox().getHeight()) + 0.15, location.getZ());
+        if (!config.getBoolean("messages.damage-visible", true)) return;
 
+        @NotNull final DecimalFormat df = new DecimalFormat("0.00");
+        @NotNull final String damage = df.format(event.getDamage());
+        @NotNull final Location location = event.getEntity().getLocation();
+        @NotNull final Location spawnLocation = new Location(location.getWorld(), location.getX(), location.getY() + (event.getEntity().getBoundingBox().getHeight()) + 0.15, location.getZ());
 
-            if (event.getCause() == EntityDamageEvent.DamageCause.PROJECTILE) {
+        if (event.getEntity().getType().equals(EntityType.DROPPED_ITEM)) return;
+
+        switch (event.getCause()) {
+            case PROJECTILE:
                 @NotNull AbstractArrow projectile = (AbstractArrow) event.getDamager();
-
                 @NotNull final Component eventMessage = hex(
                         config.getString("colors.accent.first"), single(components("[",
                                 hex(config.getString("colors.accent.third"), "i"),
@@ -40,17 +55,99 @@ public class EntityDamageListener extends TextUtils implements Listener {
                                 component(" took "),
                                 hex(config.getString("colors.accent.second"), damage, " HP"),
                                 component(" damage"))));
-
                 if (projectile.getShooter() instanceof Player player) {
                     Bukkit.getScheduler().runTaskAsynchronously(Main.getInstance(), () -> {
-                        if (config.getBoolean("messages.damage-projectile-chat-messages")) {
+                        if (config.getBoolean("messages.damage-projectile-chat-messages", true)) {
                             player.sendMessage(eventMessage);
                         }
                     });
                 }
-            }
+                break;
+            case ENTITY_ATTACK:
+                if (event.getDamager() instanceof Player player && !isHoldingSword(player)) break;
 
-            ShowDamage.show(damage, spawnLocation, event.isCritical(), config, event.getDamager());
+            case ENTITY_SWEEP_ATTACK, ENTITY_EXPLOSION, BLOCK_EXPLOSION:
+
+                if (!config.getBoolean("multiple-entity-count.enabled", true)) break;
+
+                Location damageLocation = findKeyByDistance(location, config.getDouble("multiple-entity-count.distance", 10.0)); // First, try to find the first damageData entry
+                if (damageLocation == null) {
+                    createDamageData(location, event.getCause(), damage);
+                    damageLocation = location;
+                } else {
+                    Main.MultiDamageSystem.appendToData(damageLocation);
+                }
+
+                final Location finalDamageLocation = damageLocation;
+                Bukkit.getScheduler().runTaskLater(Main.getInstance(), () -> {
+                    int count = Main.MultiDamageSystem.getCount(finalDamageLocation); // minus 1 to consider only the other entities, not the main one
+                    Main.MultiDamageSystem.reduceSizeInData(finalDamageLocation);
+                    MultiDamageEndResult endResult = getDamageResult(finalDamageLocation, event.getCause(), count);
+
+                    switch (endResult) {
+                        case SINGLE_ENTITY_ATTACK_DONE -> ShowDamage.show(damage, spawnLocation, event.isCritical(), config, event.getDamager());
+                        case SWEEP_ENTITY_ATTACK_DONE -> {
+                            String mainDamage = Main.MultiDamageSystem.getDamageDealt(finalDamageLocation);
+                            ShowDamage.show( mainDamage + " + " + (count-1) + "X" + damage, spawnLocation, event.isCritical(), config, event.getDamager());
+                        }
+                        case EXPLOSION_DONE -> ShowDamage.show(count + "X" + damage, spawnLocation, event.isCritical(), config, event.getDamager());
+
+                    }
+
+                    if (!endResult.equals(MultiDamageEndResult.NOT_DONE)) Main.MultiDamageSystem.deleteEntry(finalDamageLocation);
+
+                }, 1L);
+                return;
         }
+        ShowDamage.show(damage, spawnLocation, event.isCritical(), config, event.getDamager());
     }
+    private static boolean isHoldingSword(Player player) {
+        boolean sword = false;
+        switch (player.getInventory().getItemInMainHand().getType()) { // enhanced switch statement
+            case STONE_SWORD, DIAMOND_SWORD, GOLDEN_SWORD, IRON_SWORD, NETHERITE_SWORD, WOODEN_SWORD ->
+                    sword = true;
+        }
+        return sword;
+    }
+    private static Location findKeyByDistance(Location currentLocation, double distance){
+        Iterator<Location> it = Main.MultiDamageSystem.keySet().iterator();
+        Location damageLocation = null;
+        boolean found = false;
+        while (it.hasNext() && !found) {
+            damageLocation = it.next();
+            if (damageLocation.getWorld().equals(currentLocation.getWorld())) {
+                if (damageLocation.distance(currentLocation) <= distance) { // If the current location is within 10 (default) blocks of the first hit.
+                    found = true;
+                }
+            }
+        }
+        return damageLocation;
+    }
+    private static void createDamageData(Location damageLocation, EntityDamageEvent.DamageCause cause, String damageDealt) {
+        DamageData damageData;
+        if (cause == EntityDamageEvent.DamageCause.ENTITY_ATTACK) {
+            damageData = new DamageData(true, damageDealt);
+        } else {
+            damageData = new DamageData(false);
+
+        }
+        damageData.append();
+        Main.MultiDamageSystem.putDataInMap(damageLocation, damageData);
+    }
+
+    private static MultiDamageEndResult getDamageResult(Location damageLocation, EntityDamageEvent.DamageCause cause, int count) {
+        if (Main.MultiDamageSystem.getSize(damageLocation) == 0) {  // Reduction to 0 means there is no more entities hit as the final task was completed.
+            if (count == 1) { // A maximum count of 1 means that the final task was completed but only one entity was hit.
+                return MultiDamageEndResult.SINGLE_ENTITY_ATTACK_DONE;
+            }else {
+                if (Main.MultiDamageSystem.isDamagedBySword(damageLocation)){ // Damage was dealt by sword but more than one entity was hit, this implies a sweep attack.
+                    return MultiDamageEndResult.SWEEP_ENTITY_ATTACK_DONE;
+                }else { // Damage was dealt to multiple entities but not by a sword, this implies an explosion.
+                    return MultiDamageEndResult.EXPLOSION_DONE;
+                }
+            }
+        }
+        return MultiDamageEndResult.NOT_DONE;
+    }
+
 }

--- a/src/main/java/ru/xw1w1/showdamage/utils/DamageData.java
+++ b/src/main/java/ru/xw1w1/showdamage/utils/DamageData.java
@@ -1,0 +1,38 @@
+package ru.xw1w1.showdamage.utils;
+
+public class DamageData {
+    private int count = 0;
+    private boolean damagedBySword = false;
+    private String damageDealt;
+    private int size = 0;
+
+    public DamageData(boolean damageBySword, String damageDealt) {
+        this.damagedBySword = damageBySword;
+        this.damageDealt = damageDealt;
+
+    }
+    public DamageData(boolean damagedBySword) {
+        assert !damagedBySword : "Damaged by sword set to true but no damage value provided.";
+        this.damagedBySword = false;
+    }
+    public boolean isDamagedBySword() {
+        return damagedBySword;
+    }
+    public String getDamageDealt() {
+        return damageDealt;
+    }
+    public void append() {
+        size++;
+        count++;
+    }
+    public void reduce() {
+        size--;
+    }
+    public int count() {
+        return count;
+    }
+
+    public int size() {
+        return size;
+    }
+}

--- a/src/main/java/ru/xw1w1/showdamage/utils/ShowDamage.java
+++ b/src/main/java/ru/xw1w1/showdamage/utils/ShowDamage.java
@@ -9,7 +9,7 @@ import ru.xw1w1.showdamage.Main;
 public class ShowDamage extends TextUtils {
     public static void show(@NotNull String damage, @NotNull Location loc, boolean critical, @NotNull FileConfiguration config, @NotNull Entity damager) {
         @NotNull TextDisplay textDisplay = (TextDisplay) loc.getWorld().spawnEntity(loc, EntityType.TEXT_DISPLAY);
-        final long lifetime = config.getLong("messages.damage-popup-lifetime");
+        final long lifetime = config.getLong("damage.popup-lifetime", 25L);
 
         textDisplay.setGravity(true);
         textDisplay.setBillboard(Display.Billboard.CENTER); // Aligns the text to face towards player
@@ -17,14 +17,13 @@ public class ShowDamage extends TextUtils {
         textDisplay.setInvulnerable(true);
 
 
-        if (damager instanceof Player player && !config.getBoolean("messages.damage-visible-to-all")) {
+        if (damager instanceof Player player && !config.getBoolean("damage.visible-to-all", false)) {
             textDisplay.setVisibleByDefault(false); // This might break in the future!! Check @ApiStatus.Experimental
             player.showEntity(Main.getInstance(), textDisplay); // Might break: Check @ApiStatus.Experimental
         }
 
-        if (config.getBoolean("messages.damage-show-through-walls")) {
+        if (config.getBoolean("damage.show-through-walls", true)) {
             textDisplay.setSeeThrough(true);
-
         }
 
         textDisplay.teleport(loc);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,19 +1,31 @@
 
-# Plugin config from 20:04 13/05/2023 London Time
+# Plugin config from 16:37 16/05/2023 London Time
 
 
 # Messages settings.
 # damage-visible: damage pop-up over entity, can be false or true (by default: true)
-# damage-popup-lifetime: Value determines how long the popup will last before disappearing, 25.0 by default
 # damage-projectile-chat-messages: Sends "[i] Entity took x damage" message to projectile shooter, true by default
-# damage-visible-to-all: Sends pop-up over entity to everyone within render distance, false by default
-# damage-show-through-walls: Allows pop-up to appear through blocks and entities, true by default
 messages:
   damage-visible: true
-  damage-popup-lifetime: 25.0
   damage-projectile-chat-messages: true
-  damage-visible-to-all: false
-  damage-show-through-walls: true
+
+# damage settings.
+# visible-to-all: Sends pop-up over entity to everyone within render distance, false by default
+# show-through-walls: Allows pop-up to appear through blocks and entities, true by default
+# popup-lifetime: Value determines how long the popup will last before disappearing, 25.0 by default
+
+damage:
+  visible-to-all: false
+  show-through-walls: true
+  popup-lifetime: 25.0
+
+# multiple-entity-count settings.
+# enabled: Counts how many entities were hit with a sweep attack or explosion, true by default
+# distance: Value determines the maximum distance of blocks that damage should be considered as a total, 10 by default
+multiple-entity-count:
+  enabled: true
+  distance: 10.0
+
 
 
 # Colors for plugin


### PR DESCRIPTION
## What is new?

- New Multi-damage system, counts up the damage from one hit within a 10 (default) block radius
- TextDisplay replaced Markers to support more features
- SeeThroughWalls option which allows the pop-up to be visible through walls
- Improved PVP with new visible to all toggle, which makes popups visible for only the player that dealt it
- New pop-up lifetime option

## Bug fixes
- Removed popup's on dropped items
- Made popup's spawn relative to the height of the damaged entities' hitbox
- Improved YAML access by reducing access to once per event
- Changed TextUtils to use static methods + removed 'extends TextUtils' on damage listener class

## Plans
- Add hearts option
- Add alternate visible to all option where only PVP is affected and PVE is still visible to other players.
- Add command to disable pop-ups for the executor only
- Animation for when TextDisplays get updated in MC 1.20
.
.
.

-Maikeru-dev